### PR TITLE
updated missing controlledVocabUsed documentation

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^\.Rproj\.user$
 ^doc$
 ^Meta$
+^CRAN-SUBMISSION$

--- a/R/docDscr_variables.R
+++ b/R/docDscr_variables.R
@@ -147,6 +147,8 @@ ddi_guide <- function(...) {
 #' `docSrc` is contained in `docDscr`.
 #'
 #' @param ... Child nodes or attributes. 
+#' 
+#' @return A ddi_node object.
 #'
 #' @section Shared and complex child nodes:
 #' * [ddi_biblCit()]
@@ -160,6 +162,9 @@ ddi_guide <- function(...) {
 #' * [ddi_verStmt()]
 #'
 #' @references \href{https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/docSrc.html}{docSrc documentation}
+#' 
+#' @examples  
+#' ddi_docSrc()
 #' 
 #' @export
 ddi_docSrc <- function(...) {
@@ -227,6 +232,8 @@ ddi_docSrc <- function(...) {
 #'
 #' @param ... Child nodes or attributes. 
 #'
+#' @return A ddi_node object.
+#'
 #' @section Shared and complex child nodes:
 #' * [ddi_usage()]
 #'
@@ -237,6 +244,17 @@ ddi_docSrc <- function(...) {
 #' @references \href{https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/codeListSchemeURN.html}{codeListSchemeURN documentation}
 #' @references \href{https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/codeListURN.html}{codeListURN documentation}
 #' @references \href{https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/codeListVersionID.html}{codeListVersionID documentation}
+#' 
+#' @examples 
+#' ddi_controlledVocabUsed(ddi_codeListID("TimeMethod"),
+#'                         ddi_codeListName("Time Method"), 
+#'                         ddi_codeListAgencyName("DDI Alliance"),
+#'                         ddi_codeListVersionID("1.2"),
+#'                         ddi_codeListURN("urn:ddi-cv:TimeMethod:1.2"),
+#'                         ddi_codeListSchemeURN("
+#'                                http://www.ddialliance.org/Specification/
+#'                                DDI-CV/TimeMethod_1.2_Genericode1.0_DDI-CVProfile1.0.xml"),
+#'                         ddi_usage())
 #' 
 #' @export
 ddi_controlledVocabUsed <- function(...) {
@@ -428,11 +446,20 @@ ddi_codeListVersionID <- function(...) {
 #' valid value from the controlled vocabulary.
 #'
 #' @param ... Child nodes or attributes. 
+#' 
+#' @return A ddi_node object.
 #'
 #' @references \href{https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/usage.html}{usage documentation}
 #' @references \href{https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/attribute.html}{attribute documentation}
 #' @references \href{https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/selector.html}{selector documentation}
 #' @references \href{https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/specificElements.html}{specificElements documentation}
+#' 
+#' @examples 
+#' ddi_usage(ddi_selector("/codeBook/stdyDscr/method/dataColl/timeMeth"))
+#' 
+#' ddi_usage(ddi_selector("/codeBook/stdyDscr/method/dataProcessing"), ddi_attribute("type"))
+#' 
+#' ddi_usage(ddi_specificElements(refs = "ICPSR4328timeMeth", authorizedCodeValue = "CrossSection"))
 #' 
 #' @export
 ddi_usage <- function(...) {

--- a/man/ddi_controlledVocabUsed.Rd
+++ b/man/ddi_controlledVocabUsed.Rd
@@ -27,6 +27,9 @@ ddi_codeListVersionID(...)
 \arguments{
 \item{...}{Child nodes or attributes.}
 }
+\value{
+A ddi_node object.
+}
 \description{
 Provides a code value, as well as a reference to the code list from which
 the value is taken. Note that the CodeValue can be restricted to reference
@@ -58,6 +61,18 @@ is 1.0).
 }
 }
 
+\examples{
+ddi_controlledVocabUsed(ddi_codeListID("TimeMethod"),
+                        ddi_codeListName("Time Method"), 
+                        ddi_codeListAgencyName("DDI Alliance"),
+                        ddi_codeListVersionID("1.2"),
+                        ddi_codeListURN("urn:ddi-cv:TimeMethod:1.2"),
+                        ddi_codeListSchemeURN("
+                               http://www.ddialliance.org/Specification/
+                               DDI-CV/TimeMethod_1.2_Genericode1.0_DDI-CVProfile1.0.xml"),
+                        ddi_usage())
+
+}
 \references{
 \href{https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/controlledVocabUsed.html}{controlledVocabUsed documentation}
 

--- a/man/ddi_docSrc.Rd
+++ b/man/ddi_docSrc.Rd
@@ -9,6 +9,9 @@ ddi_docSrc(...)
 \arguments{
 \item{...}{Child nodes or attributes.}
 }
+\value{
+A ddi_node object.
+}
 \description{
 Citation for the source document. This element encodes the bibliographic
 information describing the source codebook, including title information,
@@ -41,6 +44,11 @@ attributes, can be found in the references.
 }
 }
 
+\examples{
+ 
+ddi_docSrc()
+
+}
 \references{
 \href{https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/docSrc.html}{docSrc documentation}
 }

--- a/man/ddi_usage.Rd
+++ b/man/ddi_usage.Rd
@@ -18,6 +18,9 @@ ddi_specificElements(...)
 \arguments{
 \item{...}{Child nodes or attributes.}
 }
+\value{
+A ddi_node object.
+}
 \description{
 Defines where in the instance the controlled vocabulary which is identified
 is utilized. A controlled vocabulary may occur either in the content of an
@@ -60,6 +63,14 @@ code value corresponding to the meaning of the content in the element or
 attribute when the identified element or attribute does not use an actual
 valid value from the controlled vocabulary.
 }
+}
+\examples{
+ddi_usage(ddi_selector("/codeBook/stdyDscr/method/dataColl/timeMeth"))
+
+ddi_usage(ddi_selector("/codeBook/stdyDscr/method/dataProcessing"), ddi_attribute("type"))
+
+ddi_usage(ddi_specificElements(refs = "ICPSR4328timeMeth", authorizedCodeValue = "CrossSection"))
+
 }
 \references{
 \href{https://ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/field_level_documentation_files/schemas/codebook_xsd/elements/usage.html}{usage documentation}


### PR DESCRIPTION
**Fixes requested from CRAN**
Please add \value to .Rd files regarding exported methods and explain
the functions results in the documentation. Please write about the
structure of the output (class) and also what the output means. (If a
function does not return a value, please document that too, e.g.
\value{No return value, called for side effects} or similar)
Missing Rd-tags:
      ddi_controlledVocabUsed.Rd: \value
      ddi_docSrc.Rd: \value
      ddi_usage.Rd: \value


Added `@return` and `@examples` statements to these three functions