### PR TITLE
fix: ignore NA attributes

### DIFF
--- a/R/attributes.R
+++ b/R/attributes.R
@@ -1,4 +1,7 @@
 validate_attributes <- function(attribs, allowed_attribs, field) {
+  # remove attributes with NA values
+  attribs <- Filter(Negate(is.na), attribs) 
+  
   if("lang" %in% names(attribs)) attribs <- change_lang(attribs)
   check_attribs_in_set(names(attribs), allowed_attribs, field)
   check_attribs(attribs)

--- a/tests/testthat/test_attributes.R
+++ b/tests/testthat/test_attributes.R
@@ -58,3 +58,33 @@ test_that("xs:language variable verification", {
     test_node <- build_branch_node("branchtest", attribs = list(attr = "EN GB"))
     expect_error(check_xmlLanguage(test_node$attribs), class = "rddi_error")    
 })
+
+test_that("NA values are removed/ignored", {
+  test_withNA <- ddi_codeBook(
+    ddi_stdyDscr(
+      ddi_citation(
+        ddi_titlStmt(
+          ddi_titl("Test Title", lang = NA)
+        ),
+        ddi_rspStmt(
+          ddi_AuthEnty("Author1", affiliation = NA)
+        )
+      )
+    )
+  )
+  
+  test_noNA <- ddi_codeBook(
+    ddi_stdyDscr(
+      ddi_citation(
+        ddi_titlStmt(
+          ddi_titl("Test Title")
+        ),
+        ddi_rspStmt(
+          ddi_AuthEnty("Author1")
+        )
+      )
+    )
+  )
+  
+  expect_equal(test_withNA, test_noNA)
+})

--- a/vignettes/rddi_intro.Rmd
+++ b/vignettes/rddi_intro.Rmd
@@ -192,5 +192,8 @@ xml <- as_xml(mixed_content_cb)
 xml <- gsub("&lt;", "<", xml)
 xml <- gsub("&gt;", ">", xml)
 
+# gsub converts xml variable to string so we have to change it back to xml
+xml <- xml2::read_xml(xml)
+
 write_xml(xml, "codebook.xml")
 ```


### PR DESCRIPTION
Unit test also written.

This removes NAs before a node goes through the attribute checks and removes NA values so that dataframes can be used to generate ddi_nodes. 